### PR TITLE
Small Docker compose file improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: "3.1"
+version: "3"
 
 services:
-  'laravel':
+  laravel:
     container_name: laravel
     build:
       context: Docker/
@@ -18,7 +18,7 @@ services:
       - ./Website/config/php/php.ini:/usr/local/etc/php/php.ini
       - ./Website/htdocs:/var/www/html
 
-  'ui':
+  ui:
     container_name: ui
     build:
       context: ./Website/ui/
@@ -29,7 +29,7 @@ services:
       - ./Website/ui:/usr/app/
       - frontend_node_modules:/usr/app/node_modules/
 
-  'cron':
+  cron:
     container_name: cron_job
     build:
       context: Docker/
@@ -44,7 +44,7 @@ services:
       - ./Website/config/php/php.ini:/usr/local/etc/php/php.ini
       - ./Website/htdocs:/var/www/html
 
-  'worker':
+  worker:
     container_name: worker
     restart: unless-stopped
     build:
@@ -69,12 +69,13 @@ services:
     volumes:
       - ./Website/htdocs/mpmanager:/app
 
-  'redis':
+  redis:
+    container_name: redis
     image: redis:5
     volumes:
       - ./redis/:/data
 
-  'maria':
+  maria:
     container_name: maria
     image: mariadb:10.3
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     container_name: redis
     image: redis:5
     volumes:
-      - ./redis/:/data
+      - redis_data:/data
 
   maria:
     container_name: maria
@@ -81,7 +81,7 @@ services:
     env_file:
       - ./Docker/.env
     volumes:
-      - ./DB/mysql:/var/lib/mysql
+      - mariadb_data:/var/lib/mysql
     ports:
       - 3307:3306
 
@@ -112,3 +112,5 @@ services:
 
 volumes:
   frontend_node_modules:
+  mariadb_data:
+  redis_data:


### PR DESCRIPTION
Just making the `docker-compose.yml` a bit more lean

- Removing unnecessary quotes
- Use Docker Volumes to store data instead of mounting a host folder path. It's more performant and doesn't clutter the host file system 