### PR TITLE
(infra) Remove composer container and let laravel container install d…

### DIFF
--- a/Docker/DockerfileLaravelDev
+++ b/Docker/DockerfileLaravelDev
@@ -16,14 +16,12 @@ RUN apt-get update && \
     git \
     zsh
 
-
 # install ohmyzsh
 RUN chsh -s $(which zsh)
 RUN sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 
 # add php artisan alias
 RUN echo 'alias "cmd=php artisan"'  >> ~/.zshrc
-
 
 # remove apt lists
 RUN rm -rf /var/lib/apt/lists/*
@@ -41,6 +39,11 @@ RUN touch /usr/local/etc/php/conf.d/xdebug.ini; \
     echo xdebug.remote_log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;log=/tmp/php5-xdebug.log >> /usr/local/etc/php/conf.d/xdebug.ini;
 
 COPY configuration/webserver/sites-enabled/000-default.conf /etc/apache2/sites-enabled
+
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
 RUN a2enmod ssl
 RUN a2enmod rewrite
 RUN service apache2 restart

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+cd /var/www/html/mpmanager
+php composer.phar install
+echo "Executing command: $@"
+
+# the main image's CMD arguments are somehow not passed to this script
+# so we need to check if there are any arguments and if not, execute apache2-foreground which is the default CMD of the main image
+if [ -z "$@" ]; then
+    echo "No arguments supplied, executing apache2-foreground..."
+    exec apache2-foreground
+else
+    exec "$@"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,14 +59,6 @@ services:
       - maria:db
       - redis:redis
 
-  composer:
-    container_name: mpmanager_composer
-    image: composer:2.6.5
-    restart: "no"
-    command: install --ignore-platform-reqs
-    volumes:
-      - ./Website/htdocs/mpmanager:/app
-
   redis:
     image: redis:5
     volumes:


### PR DESCRIPTION

#25 

The laravel conitainer explicitly installs the soap extension in order to use the soapClient. After evaluating both
- "Creating a custom composer image "
-  "let the laravel container install the dependencies"

 I decided to go with the 2nd option as having a separate composer container has no extra value over let the main php container install the dependencies.


## How to test;
- remove **vendor** directory
- run `docker-compose up --build` this should already re-build the **laravel** container
- expect to see the **vendor** directory in `Website/htdocs/mpmanager/`
