### PR TITLE
Remove unneeded quotes from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.1"
 
 services:
-  'laravel':
+  laravel:
     container_name: laravel
     build:
       context: Docker/
@@ -18,7 +18,7 @@ services:
       - ./Website/config/php/php.ini:/usr/local/etc/php/php.ini
       - ./Website/htdocs:/var/www/html
 
-  'ui':
+  ui:
     container_name: ui
     build:
       context: ./Website/ui/
@@ -29,7 +29,7 @@ services:
       - ./Website/ui:/usr/app/
       - frontend_node_modules:/usr/app/node_modules/
 
-  'cron':
+  cron:
     container_name: cron_job
     build:
       context: Docker/
@@ -44,7 +44,7 @@ services:
       - ./Website/config/php/php.ini:/usr/local/etc/php/php.ini
       - ./Website/htdocs:/var/www/html
 
-  'worker':
+  worker:
     container_name: worker
     restart: unless-stopped
     build:
@@ -67,12 +67,12 @@ services:
     volumes:
       - ./Website/htdocs/mpmanager:/app
 
-  'redis':
+  redis:
     image: redis:5
     volumes:
       - ./redis/:/data
 
-  'maria':
+  maria:
     container_name: maria
     image: mariadb:10.3
     env_file:


### PR DESCRIPTION
Second attempt in integrating the changes from https://github.com/EnAccess/micropowermanager-cloud/pull/24

This time in smaller, hopefully, non-breaking chunks.

## Description

Small clean up in the `docker-compose.yml` file to remove unneeded quotes.