### PR TITLE
Use volumes in Docker Compose for data storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
   'redis':
     image: redis:5
     volumes:
-      - ./redis/:/data
+      - redis_data:/data
 
   'maria':
     container_name: maria
@@ -78,7 +78,7 @@ services:
     env_file:
       - ./Docker/.env
     volumes:
-      - ./DB/mysql:/var/lib/mysql
+      - mariadb_data:/var/lib/mysql
     ports:
       - 3307:3306
 
@@ -110,3 +110,5 @@ services:
 
 volumes:
   frontend_node_modules:
+  mariadb_data:
+  redis_data:


### PR DESCRIPTION
## Description

This PR changes the `docker-compose.yml` to use Docker volumes for data storage rather than host mounts.

> [!WARNING]
> After this PR is merged, developer's local databases will be empty and require to be seeded again.

## Motivation

Using Volumes for data storage offers several benefits

- Increased performance
- Volumes are more cross-platform compatible than host file mounts. When you use volumes, you abstract away the underlying file system details of the host machine, making your setup more portable across different environments.
- Volumes provide a level of isolation between the container and the host system.