### PR TITLE
Fix Github Actions deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: docs/build/
+          path: docs/build/html/
 
   # Deployment job
   deploy:


### PR DESCRIPTION
The generated output from Sphinx is actually in `html` subfolder. Right now the documentation is accessible at https://enaccess.github.io/micropowermanager-cloud/html/index.html which is odd.