### PR TITLE
Update `yamllint` to check keys

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -9,5 +9,6 @@ rules:
     quote-type: double
     required: only-when-needed
     allow-quoted-quotes: true
+    check-keys: true
   truthy:
     check-keys: false


### PR DESCRIPTION
With the release of yamllint 1.34 we can finally check keys for unneeded quoted strings, see https://github.com/adrienverge/yamllint/blob/master/CHANGELOG.rst#1340-2024-02-06

It's also already available in Github runners natively, see here https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md