### PR TITLE
Remove uneeded `image` tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     build:
       context: Docker/
       dockerfile: DockerfileLaravelDev
-    image: laravel/php:8
     depends_on:
       - maria
     links:
@@ -34,7 +33,6 @@ services:
     build:
       context: Docker/
       dockerfile: DockerfileCron
-    image: laravel/cron
     depends_on:
       - maria
     links:


### PR DESCRIPTION
Closes: #31 

**Before:**
<img width="660" alt="image" src="https://github.com/EnAccess/micropowermanager-cloud/assets/14202480/f4d2c019-7470-4762-82f6-42d910c71c54">

**After:**
<img width="664" alt="image" src="https://github.com/EnAccess/micropowermanager-cloud/assets/14202480/3cb626ea-cffd-42e8-af7c-a4b79b85614c">

Note, how it's easier to tell which containers are build from the project and which are pulled from remote registry.