### PR TITLE
Add `.eslintrc` config for our project

### DIFF
--- a/Website/ui/.eslintrc.json
+++ b/Website/ui/.eslintrc.json
@@ -4,7 +4,8 @@
         "es2021": true,
         "amd": true,
         "jquery": true,
-        "jest": true
+        "jest": true,
+        "node": true
     },
     "globals": {
         "resources": false,
@@ -42,6 +43,7 @@
             "error",
             "never"
         ],
+        "no-unused-vars": ["error", { "varsIgnorePattern": "routes"}],
         "vue/multi-word-component-names": 0,
         "vue/no-mutating-props": 0,
         "vue/no-v-text-v-html-on-component": 0,


### PR DESCRIPTION
Currently, ESlint complains a lot about

```js
module.export(
```

and

```js
let routes =
```

which are used a lot here. Silencing the false positives.