### PR TITLE
chore: Fix Vue2 Syntax error for inline event handling

### DIFF
--- a/Website/ui/src/modules/Meter/Readings.vue
+++ b/Website/ui/src/modules/Meter/Readings.vue
@@ -38,8 +38,8 @@
             :fullscreen-mobile="true"
             :months-to-show="2"
             :offset-y="500"
-            v-on:date-one-selected="function(val) { dates.dateOne = val }"
-            v-on:date-two-selected="function(val) { dates.dateTwo = val }"
+            v-on:date-one-selected="(val) => { dates.dateOne = val }"
+            v-on:date-two-selected="(val) => { dates.dateTwo = val }"
             @apply="getConsumptions"
         ></airbnb-style-datepicker>
     </div>


### PR DESCRIPTION
Fixes 

```sh
Parsing error: Unexpected token (.eslint[vue/no-parsing-error](https://eslint.vuejs.org/rules/no-parsing-error.html)
```

Looks like it's Vue1 syntax that slipped into the code, via the example provided in the libraries Github repo.