### PR TITLE
MPM-9 Add usageType selector to Company Registration form

### DIFF
--- a/Website/ui/src/modules/Settings/MainSettings.vue
+++ b/Website/ui/src/modules/Settings/MainSettings.vue
@@ -98,7 +98,7 @@
                     <label for="usage_type">Usage Type</label>
                     <md-select name="usage_type" id="usage_type" v-model="mainSettingsService.mainSettings.usageType">
                         <md-option disabled>Select Usage Types</md-option>
-                        <md-option v-for="ut in usageTypeListService.usageTypeList" :key="ut.id"
+                        <md-option v-for="ut in usageTypeListService.list" :key="ut.id"
                                    :value="ut.value">{{ ut.name }}
                         </md-option>
                     </md-select>
@@ -140,7 +140,6 @@ export default {
             currencyList: [],
             languagesList: [],
             countryList: [],
-            usageTypeList: [],
             progress: false,
         }
 
@@ -185,7 +184,7 @@ export default {
         },
         async getUsageTypeList () {
             try {
-                await this.usageTypeListService.list()
+                await this.usageTypeListService.getUsageTypes()
             } catch (e) {
                 this.alertNotify('error', e.message)
             }

--- a/Website/ui/src/services/UsageTypeListService.js
+++ b/Website/ui/src/services/UsageTypeListService.js
@@ -4,21 +4,23 @@ import { ErrorHandler } from '@/Helpers/ErrorHander'
 export class UsageTypeListService {
     constructor() {
         this.repository = Repository.get('usageType')
-        this.usageTypeList = []
+        this.list = []
     }
 
-    async list() {
+    async getUsageTypes () {
         try {
+            this.list = []
             let response = await this.repository.list()
-            if (response.status === 200) {
-                this.usageTypeList = response.data.data
-                return this.usageTypeList
+            if (response.status === 200 || response.status === 201) {
+                this.list  = response.data.data
+                return this.list
             } else {
                 return new ErrorHandler(response.error, 'http', response.status)
             }
         } catch (e) {
-            let erorMessage = e.response.data.message
-            return new ErrorHandler(erorMessage, 'http')
+            let errorMessage = e.response.data.data.message
+            return new ErrorHandler(errorMessage, 'http')
         }
+
     }
 }


### PR DESCRIPTION
This PR adds a Usage Type selector (Dropdown) to the Company registration flow in the plugin selection.

**Additional changes:**

- Slight UI overhaul to make the company registration visually match the company config settings page
- Refactor `usageTypeListService ` to be more consistent with other services in the project.

**Preview:**
<img width="1014" alt="image" src="https://github.com/EnAccess/micropowermanager-cloud/assets/14202480/e69b21bb-429d-40c7-924e-580a93856ffe">
