### PR TITLE
chore: Resolve some deprecation warnings

### DIFF
--- a/Website/ui/src/assets/sass/mpm/_variables.scss
+++ b/Website/ui/src/assets/sass/mpm/_variables.scss
@@ -428,8 +428,8 @@ $container-lg: $container-large-desktop !default;
 $navbar-height: 50px !default;
 $navbar-margin-bottom: $line-height-computed !default;
 $navbar-border-radius: $border-radius-base !default;
-$navbar-padding-horizontal: floor(($grid-gutter-width / 2)) !default;
-$navbar-padding-vertical: (
+$navbar-padding-horizontal: floor(calc($grid-gutter-width / 2)) !default;
+$navbar-padding-vertical: calc(
     ($navbar-height - $line-height-computed) / 2
 ) !default;
 $navbar-collapse-max-height: 340px !default;
@@ -941,8 +941,8 @@ $contrast-factor: 40% !default;
 // inputs
 $mdb-input-placeholder-color: #aaaaaa !default;
 $mdb-input-underline-color: #d2d2d2 !default;
-$mdb-label-static-size-ratio: 75 / 100 !default;
-$mdb-help-block-size-ratio: 75 / 100 !default;
+$mdb-label-static-size-ratio: calc(75 / 100) !default;
+$mdb-help-block-size-ratio: calc(75 / 100) !default;
 
 $mdb-input-font-size-base: 14px !default;
 $mdb-input-font-size-large: ceil(($font-size-base * 1.25)) !default; // ~20px

--- a/Website/ui/src/assets/sass/mpm/mixins/_chartist.scss
+++ b/Website/ui/src/assets/sass/mpm/mixins/_chartist.scss
@@ -1,22 +1,22 @@
 // Scales for responsive SVG containers
 $ct-scales: (
-    (1),
-    (15/16),
-    (8/9),
-    (5/6),
-    (4/5),
-    (3/4),
-    (2/3),
-    (5/8),
-    (1/1.618),
-    (3/5),
-    (9/16),
-    (8/15),
-    (1/2),
-    (2/5),
-    (3/8),
-    (1/3),
-    (1/4)
+    calc(1),
+    calc(15 / 16),
+    calc(8 / 9),
+    calc(5 / 6),
+    calc(4 / 5),
+    calc(3 / 4),
+    calc(2 / 3),
+    calc(5 / 8),
+    calc(1 / 1.618),
+    calc(3 / 5),
+    calc(9 / 16),
+    calc(8 / 15),
+    calc(1 / 2),
+    calc(2 / 5),
+    calc(3 / 8),
+    calc(1 / 3),
+    calc(1 / 4)
 ) !default;
 $ct-scales-names: (
     ct-square,
@@ -60,7 +60,7 @@ $ct-class-start: ct-start !default;
 $ct-class-end: ct-end !default;
 
 // Container ratio
-$ct-container-ratio: (1/1.618) !default;
+$ct-container-ratio: calc(1 / 1.618) !default;
 
 // Text styles for labels
 $ct-text-color: rgba(0, 0, 0, 0.4) !default;

--- a/Website/ui/vue.config.js
+++ b/Website/ui/vue.config.js
@@ -3,4 +3,9 @@ module.exports = {
     devServer: {
         allowedHosts: 'all',
     },
+    configureWebpack: {
+        performance: {
+            hints: false,
+        },
+    },
 }


### PR DESCRIPTION
Resolves

```sh
Deprecation Warning: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div(75, 100)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
965 │ $mdb-label-static-size-ratio: 75 / 100 !default;
    │                               ^^^^^^^^
    ╵
    src/assets/sass/mpm/_variables.scss 965:31  @import
    stdin 14:9                                  root stylesheet
```

and ignores 

```
entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  app (4.74 MiB)
      css/chunk-vendors.74d80738.css
      js/chunk-vendors.66f4e743.js
      css/app.9a2eca83.css
      js/app.72d60297.js
```

as we will never be able to fix the second.